### PR TITLE
bump dependencies and use compiler optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
+checksum = "38d9ff5d688f1c13395289f67db01d4826b46dd694e7580accdc3e8430f2d98e"
 
 [[package]]
 name = "ash"
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
+checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
 dependencies = [
  "itoa",
  "ryu",
@@ -943,9 +943,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg",
  "bytes",
@@ -959,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,21 +5,26 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+codegen-units = 1
+opt-level = 3
+lto = "thin"
+
 [dependencies]
 sha3 = "0.9.1"
 miller_rabin = "1.0.6"
 byteorder = "1.4.3"
 vulkano = { git = "https://github.com/ishitatsuyuki/vulkano.git", branch = "acominer" }
 vulkano-shaders = { git = "https://github.com/ishitatsuyuki/vulkano.git", branch = "acominer" }
-serde = "1.0.126"
-serde_json = "1.0.64"
-serde_derive = "1.0.126"
+serde = "1.0.130"
+serde_json = "1.0.71"
+serde_derive = "1.0.130"
 hex = "0.4.3"
-rand = "0.8.3"
+rand = "0.8.4"
 clap = "3.0.0-beta.2"
-tokio = {version = "1.6.0", features = ["rt", "net", "io-util", "macros", "sync", "time"]}
+tokio = {version = "1.14.0", features = ["rt", "net", "io-util", "macros", "sync", "time"]}
 url = "2.2.2"
 indicatif = "0.16.2"
-ctrlc = "3.1.9"
-anyhow = "1.0.45"
+ctrlc = "3.2.1"
+anyhow = "1.0.47"
 backoff = "0.3.0"


### PR DESCRIPTION
Does as the title says. This PR bumps dependencies in Cargo.toml, alongside enabling thin LTO and O3 optimizations when building for release.